### PR TITLE
Do not update schema.rb for projects using ActiveRecord.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/lib/application_seeds/database.rb
+++ b/lib/application_seeds/database.rb
@@ -18,6 +18,9 @@ module ApplicationSeeds
       end
 
       def create_metadata_table
+        if defined?(ActiveRecord)
+          ActiveRecord::SchemaDumper.ignore_tables = ["application_seeds"]
+        end
         connection.exec('DROP TABLE IF EXISTS application_seeds;')
         connection.exec('CREATE TABLE application_seeds (dataset varchar(255));')
       end


### PR DESCRIPTION
This change will not add the application_seeds table to the schema.rb file.  It also adds a rake task for rspec and makes it the default.
