### PR TITLE
Stop storing the dataset loaded in the database.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+v0.7.0, 2014-05-02
+------------------
+
+  * Stop storing the dataset in the database.  Removed the
+    `ApplicationSeeds.dataset` method.
+
+
 v0.6.0, 2014-03-06
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -443,16 +443,6 @@ Specify the name of the dataset to use.  An exception will be raised if
 the dataset could not be found.
 
 
-### Determining the dataset that has been loaded
-
-```ruby
-ApplicationSeeds.dataset
-```
-
-Returns the name of the dataset that has been loaded, or nil if not
-running an application_seeds dataset.
-
-
 ### Checking if a seed file exists in the dataset
 
 ```ruby

--- a/lib/application_seeds.rb
+++ b/lib/application_seeds.rb
@@ -95,19 +95,6 @@ module ApplicationSeeds
         error_message << "Available datasets: #{datasets}\n\n"
         raise error_message
       end
-
-      store_dataset
-    end
-
-    #
-    # Returns the name of the dataset that has been loaded, or nil if not
-    # running an application_seeds dataset.
-    #
-    def dataset
-      res = Database.connection.exec("SELECT dataset from application_seeds LIMIT 1;")
-      res.getvalue(0, 0)
-    rescue PG::Error => e
-      e.message =~ /relation "application_seeds" does not exist/ ? nil : raise
     end
 
     #
@@ -171,11 +158,6 @@ module ApplicationSeeds
 
     def dataset_path(dataset)
       Dir[File.join(seed_data_path, "**", "*")].select { |x| File.directory?(x) && File.basename(x) == dataset }.first
-    end
-
-    def store_dataset
-      Database.create_metadata_table
-      Database.connection.exec("INSERT INTO application_seeds (dataset) VALUES ('#{@dataset}');")
     end
 
     def seed_data_path

--- a/lib/application_seeds/database.rb
+++ b/lib/application_seeds/database.rb
@@ -17,11 +17,6 @@ module ApplicationSeeds
         @connection = PG.connect(pg_config)
       end
 
-      def create_metadata_table
-        connection.exec('DROP TABLE IF EXISTS application_seeds;')
-        connection.exec('CREATE TABLE application_seeds (dataset varchar(255));')
-      end
-
       def without_foreign_keys
         drop_foreign_keys_sql = generate_drop_foreign_keys_sql
         create_foreign_keys_sql = generate_create_foreign_keys_sql
@@ -59,8 +54,4 @@ module ApplicationSeeds
 
     end
   end
-end
-
-if defined?(ActiveRecord)
-  ActiveRecord::SchemaDumper.ignore_tables = ["application_seeds"]
 end

--- a/lib/application_seeds/version.rb
+++ b/lib/application_seeds/version.rb
@@ -1,3 +1,3 @@
 module ApplicationSeeds
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end

--- a/spec/application_seeds_spec.rb
+++ b/spec/application_seeds_spec.rb
@@ -74,27 +74,11 @@ describe "ApplicationSeeds" do
 
     context "when a valid dataset is specified" do
       before do
-        connection_dummy = double
-        connection_dummy.should_receive(:exec).with("INSERT INTO application_seeds (dataset) VALUES ('test_data_set');")
-        ApplicationSeeds::Database.should_receive(:create_metadata_table)
-        ApplicationSeeds::Database.should_receive(:connection) { connection_dummy }
         ApplicationSeeds.dataset = "test_data_set"
       end
       it "sets the dataset" do
         expect(ApplicationSeeds.instance_variable_get(:@dataset)).to eql("test_data_set")
       end
-    end
-  end
-
-  describe "#dataset" do
-    before do
-      connection_dummy = double
-      response_dummy = double(:getvalue => "test_data_set")
-      connection_dummy.should_receive(:exec).with("SELECT dataset from application_seeds LIMIT 1;") { response_dummy }
-      ApplicationSeeds::Database.should_receive(:connection) { connection_dummy }
-    end
-    it "fetches the dataset name from the database" do
-      expect(ApplicationSeeds.dataset).to eql("test_data_set")
     end
   end
 


### PR DESCRIPTION
This feature is not used, and causes the appliation_seeds table to show up in db/structure.sql
