### PR TITLE
Use hashes with indifferent access for attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v0.8.0, 2014-06-13
+v0.8.0, 2014-06-20
 ------------------
 
   * Use hashes with indifferent access for the attributes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v0.8.0, 2014-06-13
+------------------
+
+  * Use hashes with indifferent access for the attributes.
+
+
 v0.7.0, 2014-05-02
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ does not.
 ApplicationSeeds.campaigns  # where "campaigns" is the name of the seed file
 ```
 
-This call returns a hash with one or more entries (depending on the contentes of the seed file).
+This call returns a hash with one or more entries (depending on the contents of the seed file).
 The IDs of the object are the keys, and a hash containing the object's attributes are the values.
 An exception is raised if no seed data could be with the given name.
 
@@ -490,13 +490,18 @@ seed data could be found with the given ID.
 ApplicationSeeds.campaigns(foo: 'bar', name: 'John')  # where "campaigns" is the name of the seed file
 ```
 
-This call returns the seed data that contains the specified attributes,
-and the specified attribute values.  It returns a hash with zero or more
-entries.  The IDs of the object are the keys of the hash, and a hash
-containing the object's attributes are the values.  Any empty hash will
-be returned if no seed data could be found with the given attribute names
-and values.
+This call returns the seed data that contains the specified attributes, and the specified attribute values.  It returns a hash with zero or more entries.  The IDs of the object are the keys of the hash, and a hash containing the object's attributes are the values. Any empty hash will be returned if no seed data could be found with the given attribute names and values.
 
+
+### Accessing attributes
+
+A seed datum is a hash of attributes (with indifferent access):
+
+```ruby
+campaign = ApplicationSeeds.campaigns(642)
+campaign["description"] # => "Best pizza in Chicago"
+campaign[:budget]       # => 10000
+```
 
 ### Creating an object
 
@@ -506,7 +511,6 @@ ApplicationSeeds.create_object!(Campaign, id, attributes)
 
 This call will create a new instance of the `Campaign` class, with the
 specified id and attributes.
-
 
 ### Rejecting specific attributes
 

--- a/lib/application_seeds/attributes.rb
+++ b/lib/application_seeds/attributes.rb
@@ -9,24 +9,19 @@ module ApplicationSeeds
 
     def select_attributes(*attribute_names)
       attribute_names.map!(&:to_s)
-      Attributes.new(select { |k,v| attribute_names.include?(k) })
+      Attributes.new(select { |k, v| attribute_names.include?(k) })
     end
 
     def reject_attributes(*attribute_names)
       attribute_names.map!(&:to_s)
-      Attributes.new(reject { |k,v| attribute_names.include?(k) })
+      Attributes.new(reject { |k, v| attribute_names.include?(k) })
     end
 
     def map_attributes(mapping)
-      mapping.stringify_keys!
-
-      mapped = {}
-      each do |k,v|
-        if mapping.keys.include?(k)
-          mapped[mapping[k].to_s] = v
-        else
-          mapped[k] = v
-        end
+      mapping = mapping.with_indifferent_access
+      mapped  = inject({}) do |hash, (k, v)|
+        mapped_key = mapping.fetch(k) { k }
+        hash.merge!(mapped_key => v)
       end
       Attributes.new(mapped)
     end

--- a/lib/application_seeds/attributes.rb
+++ b/lib/application_seeds/attributes.rb
@@ -1,10 +1,10 @@
 require 'delegate'
 
 module ApplicationSeeds
-  class Attributes < DelegateClass(Hash)
+  class Attributes < DelegateClass(ActiveSupport::HashWithIndifferentAccess)
 
     def initialize(attributes)
-      super(attributes)
+      super(attributes.with_indifferent_access)
     end
 
     def select_attributes(*attribute_names)

--- a/lib/application_seeds/version.rb
+++ b/lib/application_seeds/version.rb
@@ -1,3 +1,3 @@
 module ApplicationSeeds
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end

--- a/spec/application_seeds_spec.rb
+++ b/spec/application_seeds_spec.rb
@@ -272,7 +272,7 @@ describe "ApplicationSeeds" do
         person = ApplicationSeeds.people(:sam_jones)
         expect(person['first_name']).to eql("Sam")
       end
-      it "gives the data in lower levels precendence" do
+      it "gives the data in lower levels precedence" do
         person = ApplicationSeeds.people(:ken_adams)
         expect(person['first_name']).to eql("Ken")
       end
@@ -283,7 +283,7 @@ describe "ApplicationSeeds" do
         expect(ApplicationSeeds.config_value(:num_companies)).to eql(5)
         expect(ApplicationSeeds.config_value(:num_departments)).to eql(3)
       end
-      it "gives the data in lower levels precendence" do
+      it "gives the data in lower levels precedence" do
         expect(ApplicationSeeds.config_value(:num_people)).to eql(10)
       end
     end

--- a/spec/application_seeds_spec.rb
+++ b/spec/application_seeds_spec.rb
@@ -84,7 +84,7 @@ describe "ApplicationSeeds" do
 
   context "with a valid dataset" do
     before do
-      ApplicationSeeds.stub(:store_dataset)
+      allow(ApplicationSeeds).to receive(:store_dataset)
       ApplicationSeeds.dataset = "test_data_set"
     end
 
@@ -235,7 +235,7 @@ describe "ApplicationSeeds" do
 
   describe "with a nested dataset" do
     before do
-      ApplicationSeeds.stub(:store_dataset)
+      allow(ApplicationSeeds).to receive(:store_dataset)
       ApplicationSeeds.dataset = "level_3"
     end
 
@@ -292,7 +292,7 @@ describe "ApplicationSeeds" do
   describe "with UUIDs configured for all seed types" do
     before do
       ApplicationSeeds.instance_variable_set("@dataset", nil)
-      ApplicationSeeds.stub(:store_dataset)
+      allow(ApplicationSeeds).to receive(:store_dataset)
       ApplicationSeeds.config = { :id_type => :uuid }
       ApplicationSeeds.dataset = "test_data_set"
     end
@@ -311,7 +311,7 @@ describe "ApplicationSeeds" do
   describe "with data type specific key types configured" do
     before do
       ApplicationSeeds.instance_variable_set("@dataset", nil)
-      ApplicationSeeds.stub(:store_dataset)
+      allow(ApplicationSeeds).to receive(:store_dataset)
       ApplicationSeeds.config = { :id_type => :uuid, :companies_id_type => :integer }
       ApplicationSeeds.dataset = "test_data_set"
     end

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -45,7 +45,7 @@ describe "Attributes" do
 
   describe "#map_attributes" do
     before do
-      @mapped_attributes = @attributes.map_attributes(:first_name => :fname, :last_name => :lname)
+      @mapped_attributes = @attributes.map_attributes(:first_name => :fname, 'last_name' => 'lname')
     end
     it "uses the new keys" do
       expect(@mapped_attributes).to eql({ "fname" => "Billy", "lname" => "Bob", "occupation" => "Bus Driver", "major_house" => "Atreides" })

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -4,7 +4,19 @@ describe "Attributes" do
   before do
     @attributes = ApplicationSeeds::Attributes.new("first_name" => "Billy",
                                                    "last_name"  => "Bob",
-                                                   "occupation" => "Bus Driver")
+                                                   "occupation" => "Bus Driver",
+                                                   major_house: "Atreides")
+  end
+
+  describe "attribute access" do
+    it "works with a string key" do
+      expect(@attributes["first_name"]).to eq("Billy")
+      expect(@attributes["major_house"]).to eq("Atreides")
+    end
+    it "works with a symbol key" do
+      expect(@attributes[:first_name]).to eq("Billy")
+      expect(@attributes[:major_house]).to eq("Atreides")
+    end
   end
 
   describe "#select_attributes" do
@@ -21,7 +33,7 @@ describe "Attributes" do
 
   describe "#reject_attributes" do
     before do
-      @rejected_attributes = @attributes.reject_attributes(:first_name, :last_name)
+      @rejected_attributes = @attributes.reject_attributes(:first_name, :last_name, :major_house)
     end
     it "returns only the select attributes" do
       expect(@rejected_attributes).to eql({ "occupation" => "Bus Driver" })
@@ -35,8 +47,8 @@ describe "Attributes" do
     before do
       @mapped_attributes = @attributes.map_attributes(:first_name => :fname, :last_name => :lname)
     end
-    it "returns only the select attributes" do
-      expect(@mapped_attributes).to eql({ "fname" => "Billy", "lname" => "Bob", "occupation" => "Bus Driver" })
+    it "uses the new keys" do
+      expect(@mapped_attributes).to eql({ "fname" => "Billy", "lname" => "Bob", "occupation" => "Bus Driver", "major_house" => "Atreides" })
     end
     it "returns a new instance of the Attributes class" do
       expect(@mapped_attributes).to be_a(ApplicationSeeds::Attributes)

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -21,7 +21,7 @@ describe "Attributes" do
 
   describe "#select_attributes" do
     before do
-      @selected_attributes = @attributes.select_attributes(:first_name, :occupation)
+      @selected_attributes = @attributes.select_attributes(:first_name, "occupation")
     end
     it "returns only the select attributes" do
       expect(@selected_attributes).to eql({ "first_name" => "Billy", "occupation" => "Bus Driver" })
@@ -33,7 +33,7 @@ describe "Attributes" do
 
   describe "#reject_attributes" do
     before do
-      @rejected_attributes = @attributes.reject_attributes(:first_name, :last_name, :major_house)
+      @rejected_attributes = @attributes.reject_attributes(:first_name, :last_name, "major_house")
     end
     it "returns only the select attributes" do
       expect(@rejected_attributes).to eql({ "occupation" => "Bus Driver" })


### PR DESCRIPTION
Use strings or symbols when defining the attributes of objects in YAML files.

Use strings or symbols to access the values from an attribute hash.

We're now completely indifferent.
